### PR TITLE
VCST-5163: Stable 15 — Contracts (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.Contract.Web/package-lock.json
+++ b/src/VirtoCommerce.Contract.Web/package-lock.json
@@ -1,3 +1,10 @@
 {
-  "lockfileVersion": 1
+  "name": "VirtoCommerce.Contract.Web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "VirtoCommerce.Contract.Web"
+    }
+  }
 }

--- a/src/VirtoCommerce.Contracts.Core/VirtoCommerce.Contracts.Core.csproj
+++ b/src/VirtoCommerce.Contracts.Core/VirtoCommerce.Contracts.Core.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CustomerModule.Core" Version="3.1011.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.Contracts.Data.MySql/VirtoCommerce.Contracts.Data.MySql.csproj
+++ b/src/VirtoCommerce.Contracts.Data.MySql/VirtoCommerce.Contracts.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Contracts.Data\VirtoCommerce.Contracts.Data.csproj" />

--- a/src/VirtoCommerce.Contracts.Data.PostgreSql/VirtoCommerce.Contracts.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.Contracts.Data.PostgreSql/VirtoCommerce.Contracts.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Contracts.Data\VirtoCommerce.Contracts.Data.csproj" />

--- a/src/VirtoCommerce.Contracts.Data.SqlServer/VirtoCommerce.Contracts.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.Contracts.Data.SqlServer/VirtoCommerce.Contracts.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Contracts.Data\VirtoCommerce.Contracts.Data.csproj" />

--- a/src/VirtoCommerce.Contracts.Data/ExportImport/ContractsExportImport.cs
+++ b/src/VirtoCommerce.Contracts.Data/ExportImport/ContractsExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.Collections.Generic;
 using System.IO;
@@ -29,12 +30,12 @@ public class ContractsExportImport(
 
         await using var sw = new StreamWriter(outStream);
         await using var writer = new JsonTextWriter(sw);
-        await writer.WriteStartObjectAsync();
+        await writer.WriteStartObjectAsync(cancellationToken);
 
         progressInfo.Description = "Contracts are started to export";
         progressCallback(progressInfo);
 
-        await writer.WritePropertyNameAsync("Contracts");
+        await writer.WritePropertyNameAsync("Contracts", cancellationToken);
         await writer.SerializeArrayWithPagingAsync(jsonSerializer, BatchSize, async (skip, take) =>
         {
             var searchCriteria = AbstractTypeFactory<ContractSearchCriteria>.TryCreateInstance();
@@ -48,8 +49,8 @@ public class ContractsExportImport(
             progressCallback(progressInfo);
         }, cancellationToken);
 
-        await writer.WriteEndObjectAsync();
-        await writer.FlushAsync();
+        await writer.WriteEndObjectAsync(cancellationToken);
+        await writer.FlushAsync(cancellationToken);
     }
 
     public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
@@ -60,7 +61,7 @@ public class ContractsExportImport(
 
         using var streamReader = new StreamReader(inputStream);
         await using var reader = new JsonTextReader(streamReader);
-        while (await reader.ReadAsync())
+        while (await reader.ReadAsync(cancellationToken))
         {
             if (reader.TokenType == JsonToken.PropertyName &&
                 reader.Value?.ToString() == "Contracts")
@@ -79,10 +80,10 @@ public class ContractsExportImport(
     private static async Task SafeDeserializeArrayWithPagingAsync<T>(JsonTextReader reader, JsonSerializer serializer, int pageSize,
        ExportImportProgressInfo progressInfo, Func<IList<T>, Task> action, Action<int> progressCallback, CancellationToken cancellationToken)
     {
-        await reader.ReadAsync();
+        await reader.ReadAsync(cancellationToken);
         if (reader.TokenType == JsonToken.StartArray)
         {
-            await reader.ReadAsync();
+            await reader.ReadAsync(cancellationToken);
 
             var items = new List<T>();
             var processedCount = 0;
@@ -101,7 +102,7 @@ public class ContractsExportImport(
                 }
 
                 processedCount++;
-                await reader.ReadAsync();
+                await reader.ReadAsync(cancellationToken);
                 if (processedCount % pageSize == 0 || reader.TokenType == JsonToken.EndArray)
                 {
                     await action(items);

--- a/src/VirtoCommerce.Contracts.Data/ExportImport/ContractsExportImport.cs
+++ b/src/VirtoCommerce.Contracts.Data/ExportImport/ContractsExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -19,7 +20,7 @@ public class ContractsExportImport(
 {
     private const int BatchSize = 50;
 
-    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -51,7 +52,7 @@ public class ContractsExportImport(
         await writer.FlushAsync();
     }
 
-    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+    public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -76,7 +77,7 @@ public class ContractsExportImport(
     }
 
     private static async Task SafeDeserializeArrayWithPagingAsync<T>(JsonTextReader reader, JsonSerializer serializer, int pageSize,
-       ExportImportProgressInfo progressInfo, Func<IList<T>, Task> action, Action<int> progressCallback, ICancellationToken cancellationToken)
+       ExportImportProgressInfo progressInfo, Func<IList<T>, Task> action, Action<int> progressCallback, CancellationToken cancellationToken)
     {
         await reader.ReadAsync();
         if (reader.TokenType == JsonToken.StartArray)

--- a/src/VirtoCommerce.Contracts.Data/VirtoCommerce.Contracts.Data.csproj
+++ b/src/VirtoCommerce.Contracts.Data/VirtoCommerce.Contracts.Data.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Contracts.Core\VirtoCommerce.Contracts.Core.csproj" />

--- a/src/VirtoCommerce.Contracts.ExperienceApi/VirtoCommerce.Contracts.ExperienceApi.csproj
+++ b/src/VirtoCommerce.Contracts.ExperienceApi/VirtoCommerce.Contracts.ExperienceApi.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Contracts.Core\VirtoCommerce.Contracts.Core.csproj" />

--- a/src/VirtoCommerce.Contracts.Web/Module.cs
+++ b/src/VirtoCommerce.Contracts.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Threading.Tasks;
 using FluentValidation;
@@ -131,14 +132,14 @@ namespace VirtoCommerce.Contracts.Web
         }
 
         public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<ContractsExportImport>().DoExportAsync(outStream, progressCallback, cancellationToken);
 
         }
 
         public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback,
-            ICancellationToken cancellationToken)
+            CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<ContractsExportImport>().DoImportAsync(inputStream, progressCallback, cancellationToken);
 

--- a/src/VirtoCommerce.Contracts.Web/module.manifest
+++ b/src/VirtoCommerce.Contracts.Web/module.manifest
@@ -4,12 +4,12 @@
   <version>3.1003.0</version>
   <version-tag />
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Customer" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Pricing" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Customer" version="3.1011.0" />
+    <dependency id="VirtoCommerce.Pricing" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
   </dependencies>
 
   <title>Contracts</title>

--- a/tests/VirtoCommerce.Contracts.Tests/VirtoCommerce.Contracts.Tests.csproj
+++ b/tests/VirtoCommerce.Contracts.Tests/VirtoCommerce.Contracts.Tests.csproj
@@ -9,7 +9,7 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 6). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–5 packages on nuget.org. Version handled by CI.

- ICancellationToken→CancellationToken migration; deps bumped (Customer 3.1011.0, Xapi 3.1012.0).
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contract export/import and module wiring against a major platform bump; behavior should be equivalent but regression risk is mainly in long-running import/export cancellation and compatibility with the new platform packages.
> 
> **Overview**
> Aligns the Contracts module with **Stable 15** by targeting VirtoCommerce platform **3.1039.0** and bumping related NuGet/module dependencies (Customer, Pricing, Store, Xapi, and platform data packages).
> 
> Updates export/import cancellation handling to use **`CancellationToken`** instead of the platform **`ICancellationToken`** abstraction in `ContractsExportImport` and the web `Module` export/import entry points, matching the updated platform export/import APIs.
> 
> Also refreshes **`module.manifest`** dependency versions, bumps **coverlet.collector** in tests, and modernizes the web **`package-lock.json`** format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04225e7a5c0154560f2dc216d6f981df432f750d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Contracts_3.1003.0-pr-38-4360.zip