### PR TITLE
VCST-5468: Resolve mediators per request

### DIFF
--- a/src/VirtoCommerce.Contracts.Data/VirtoCommerce.Contracts.Data.csproj
+++ b/src/VirtoCommerce.Contracts.Data/VirtoCommerce.Contracts.Data.csproj
@@ -10,7 +10,7 @@
     
     <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
     <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
-    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1006.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Contracts.Core\VirtoCommerce.Contracts.Core.csproj" />

--- a/src/VirtoCommerce.Contracts.ExperienceApi/Queries/ContractQueryBuilder.cs
+++ b/src/VirtoCommerce.Contracts.ExperienceApi/Queries/ContractQueryBuilder.cs
@@ -13,8 +13,8 @@ namespace VirtoCommerce.Contracts.ExperienceApi.Queries
     {
         protected override string Name => "contract";
 
-        public ContractQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-            : base(mediator, authorizationService)
+        public ContractQueryBuilder(IAuthorizationService authorizationService)
+            : base(authorizationService)
         {
         }
 

--- a/src/VirtoCommerce.Contracts.ExperienceApi/Queries/OrganizationContractsQueryBuilder.cs
+++ b/src/VirtoCommerce.Contracts.ExperienceApi/Queries/OrganizationContractsQueryBuilder.cs
@@ -14,8 +14,8 @@ namespace VirtoCommerce.Contracts.ExperienceApi.Queries
     {
         protected override string Name => "organizationContracts";
 
-        public OrganizationContractsQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-            : base(mediator, authorizationService)
+        public OrganizationContractsQueryBuilder(IAuthorizationService authorizationService)
+            : base(authorizationService)
         {
 
         }

--- a/src/VirtoCommerce.Contracts.ExperienceApi/VirtoCommerce.Contracts.ExperienceApi.csproj
+++ b/src/VirtoCommerce.Contracts.ExperienceApi/VirtoCommerce.Contracts.ExperienceApi.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.Contracts.Core\VirtoCommerce.Contracts.Core.csproj" />

--- a/src/VirtoCommerce.Contracts.Web/module.manifest
+++ b/src/VirtoCommerce.Contracts.Web/module.manifest
@@ -8,8 +8,8 @@
   <dependencies>
     <dependency id="VirtoCommerce.Customer" version="3.1011.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" />
-    <dependency id="VirtoCommerce.Store" version="3.1005.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1006.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
   </dependencies>
 
   <title>Contracts</title>


### PR DESCRIPTION
## Summary

- migrate Contracts GraphQL query builders to the request-scoped XApi mediator contract
- align XApi and Store dependencies in project and module manifest references

## Why

GraphQL builders are singletons. Resolving `IMediator` from `context.RequestServices` for each operation preserves request-scoped dependency lifetimes. The normal query handler remains unchanged because it is not a singleton GraphQL component.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GraphQL request dispatch and DI lifetimes for contract queries; incorrect mediator scoping could affect request-scoped handlers, though scope is limited to two builders plus dependency bumps.
> 
> **Overview**
> **Contracts GraphQL query builders** (`ContractQueryBuilder`, `OrganizationContractsQueryBuilder`) no longer take `IMediator` in their constructors and only pass `IAuthorizationService` into the XApi base types. That matches the updated **VirtoCommerce.Xapi.Core** contract where singleton builders must not hold a mediator instance and instead rely on per-request resolution (e.g. from `RequestServices`).
> 
> Dependency versions are bumped to use that stack: **Xapi** `3.1012.0` → `3.1015.0` (Experience API project + module manifest), **Store** `3.1005.0` → `3.1006.0` (Data project + manifest). A trailing newline is added to the Data `.csproj`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e5d389d670c8c27b1d8ef7d7e98390001e3b77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Contracts_3.1004.0-pr-39-f2e5.zip